### PR TITLE
Fix typo in Login.js

### DIFF
--- a/client/src/containers/Login.js
+++ b/client/src/containers/Login.js
@@ -66,7 +66,7 @@ class Login extends Component {
             this.setState({
               loggedIn: true,
               showError: false,
-              showENullrror: false,
+              showNullError: false,
             });
           }
         })


### PR DESCRIPTION
Replaces `showENullrror` with `showNullError` (which I believe to be the correct version ;).