### PR TITLE
Add missing showNullError updates

### DIFF
--- a/client/src/containers/ForgotPassword.js
+++ b/client/src/containers/ForgotPassword.js
@@ -24,6 +24,7 @@ class ForgotPassword extends Component {
       email: '',
       showError: false,
       messageFromServer: '',
+      showNullError: false,
     };
   }
 
@@ -39,6 +40,7 @@ class ForgotPassword extends Component {
       this.setState({
         showError: false,
         messageFromServer: '',
+        showNullError: true,
       });
     } else {
       axios
@@ -51,11 +53,13 @@ class ForgotPassword extends Component {
             this.setState({
               showError: true,
               messageFromServer: '',
+              showNullError: false,
             });
           } else if (response.data === 'recovery email sent') {
             this.setState({
               showError: false,
               messageFromServer: 'recovery email sent',
+              showNullError: false,
             });
           }
         })


### PR DESCRIPTION
There is a conditional `showNullError` section in ForgotPassword.js, but since `showNullError` is never updated, I don't think this would ever be shown. I've added the necessary state updates to the `setState` calls and the constructor. Haven't tested whether this works (wrote it in the GitHub editor), but I don't have any reason to believe that it wouldn't 🙂

Thanks for the great resource by the way, this repository is a definite time-saver in getting a working authentication setup going 🙂